### PR TITLE
Feature#6 documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+
+# Created by https://www.gitignore.io/api/go,macos,windows,intellij,visualstudiocode
+# Edit at https://www.gitignore.io/?templates=go,macos,windows,intellij,visualstudiocode
+
+### Go ###
 # Binaries for programs and plugins
 *.exe
 *.exe~
@@ -5,11 +10,174 @@
 *.so
 *.dylib
 
-# Test binary, build with `go test -c`
+# Test binary, built with `go test -c`
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-#.vscode configuration files
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+### Go Patch ###
+/vendor/
+/Godeps/
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator/
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### VisualStudioCode ###
 .vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.gitignore.io/api/go,macos,windows,intellij,visualstudiocode
+
+# Each team member has its own environment to work on Kadok. The IDE files are fully removed as of today.
+.vscode/**
+.idea/**

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+kadok.pedestres.fr

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,9 @@
+title: Kadok
+remote_theme: pmarsceill/just-the-docs
+description: "Where's Kadoc? Is he well hidden?"
+footer_content: "Kadok is maintained by the team of \"Les Petits Pédestres\" under the <a href=\"https://github.com/Terag/kadok/blob/master/LICENSE\">GNU GENERAL PUBLIC LICENSE Version 3.</a>"
+color_scheme: nil
+search_enabled: false
+aux_links:
+  "Kadok on GitHub":
+    - "//github.com/Terag/kadok"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,48 @@
+# Contributing to Kadok's development
+
+Hi there! We are happy that you would like to contribute to Kadok!
+
+Kadok is an open source discord bot. Following these development guidelines will help to keep the project clean and running. 
+
+## How to report a bug
+
+Think you found a bug? Please check [the list of open issues](https://github.com/terag/kadok/issues).
+
+Here are a few tips for writing *great* bug reports:
+
+* Describe the specific problem (e.g., "widget doesn't turn clockwise" versus "getting an error")
+* Include the steps to reproduce the bug, what you expected to happen, and what happened instead
+* Check that you are using the latest version of the project and its dependencies
+* Include what version of the project your using, as well as any relevant dependencies
+* Only include one bug per issue. If you have discovered two bugs, please file two issues
+* Even if you don't know how to fix the bug, including a failing test may help others track it down
+
+## How to suggest a feature or enhancement
+
+If you find yourself wishing for a feature that doesn't exist in Kadok, please write an issue following this template:
+
+```markdown
+# What
+
+(what is the feature about)
+
+# Why
+
+(why would this feature be great ?)
+
+# Who would benefit
+
+(for who ?)
+
+# Functional criteria
+
+(Information on how the feature should behave)
+
+# Proposal
+
+(Few proposal for the developers)
+```
+
+## Your first contribution
+
+We'd love for you to contribute to the project. Please contact one of the 3 main contributors to know how to proceed

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -1,0 +1,113 @@
+# Developers Documentation
+
+The purpose of this page is to help you understand how Kadok is organized.
+
+## Code Organization
+
+The main package holds the global structure of the bot and is also the only package importing and using the SDK DiscordGo.
+Other packages are responsible to deliver domain specific features such as security features or characters features.
+
+When you find yourself developing features for a new category, please create the associated package containing
+the functions associated to your category.
+
+If the category needs a configuration or load external files, you should take example on other packages and create
+a custom Properties structure with its own UnmarshalYAML implementation. You then can add it to the Properties structure
+in the main package.
+
+## How to add a Feature
+
+In this example, we assume that the functions required by your feature already exist in the right package.
+The objective here is to add it to the current action tree and make it callable by the users.
+
+The action tree is the hierarchy of possible actions. Most of the actions have the option to implement a help feature that can
+called like this `kadok <you-command> help` (example: `kadok minecraft help`, it can also be called on the root command `kadok help` for general information about the bot).
+Example of commands hierarchy:
+
+```
+ kadok
+ ├─ aqui
+ ├─ ping
+ ├─ pong
+ ├─ minecraft
+ |    ├─ status
+ |    ├─ whitelist <username>
+ |    └─ blacklist <username>
+ └─ dice <dices-pattern>
+```
+
+In Kadok, you have two ways of adding an action to the current action tree:
+
+- The most customizable is by implementing the interface **ActionResolver** from the file actions.go.
+- The out of the box one is by creating a new **Action** global variable
+
+```go
+package main
+
+type ExecuteAction func(s *discordgo.Session, m *discordgo.MessageCreate) error
+
+type ActionResolver interface {
+	// Required by the security package.
+    GetPermission() security.Permission
+    // Resolve the call and return the ActionResolver with a function to execute it.
+    ResolveAction(call []string) (ActionResolver, ExecuteAction)
+}
+
+type Action struct {
+    // The permission required to use this action. Use the EmptyPermission if no permission is required
+    Permission  security.Permission
+    // The sub actions in the hierarchy. They do not inherit the permission requirement
+    SubActions  map[string]ActionResolver
+    // The function to execute when the action is called
+    Execute     func(s *discordgo.Session, m *discordgo.MessageCreate, parameters []string) error
+    // The function to display information about the action
+    DisplayHelp func(s *discordgo.Session, m *discordgo.MessageCreate) error
+}
+```
+
+In this example we will use the out of the box option.
+For that you simply have to add a new Action to the list of available Actions as a global variable.
+
+Don't forget to add a permission in security/rbac.go if you need a new permission. It will directly by available for use in the configuration files.
+
+You then need to reference it in the parent action for it to be added to the hierarchy (it is true for both methods).
+The key in the map should be UPPERCASE as the bot is case-insensitive.
+
+The RootAction is the root node of the tree. It is called first by Kadok to resolve the action.
+
+Create the Action:
+
+```go
+package main
+
+var(
+	PingAction = Action{
+		security.GetCharacterList,
+		map[string]ActionResolver{},
+		func(s *discordgo.Session, m *discordgo.MessageCreate, parameters []string) error {
+			_, err := s.ChannelMessageSend(m.ChannelID, "À Kadoc ! À Kadoc ! Pong!")
+			return err
+		},
+		func(s *discordgo.Session, m *discordgo.MessageCreate) error {
+			_, err := s.ChannelMessageSend(m.ChannelID, "Kadok répond pong!")
+			return err
+		},
+	}
+
+	RootAction = Action{
+		security.GetHelp,
+		map[string]ActionResolver{
+			"PONG": &PongAction,
+		},
+		func(s *discordgo.Session, m *discordgo.MessageCreate, parameters []string) error {
+			return errors.New("Not a valid action")
+		},
+		func(s *discordgo.Session, m *discordgo.MessageCreate) error {
+			message := ""
+			message += "\nTatan elle fait du flan, elle m'a aussi dit de dire des choses intelligentes si on m'appel: 'AKadok'"
+			message += "\n'Kadok aqui' ? Je dis tous mes amis !"
+			_, err := s.ChannelMessageSend(m.ChannelID, message)
+			return err
+		},
+	}
+)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,6 @@
 
 # Who is Kadok ?
 
-
 Kadok is a bot developed for the Discord Guild "Les petits pedestres".
 It aims to provide fun and useful functionnalities for the Guild Members.
 
@@ -22,18 +21,6 @@ The current available features are:
 - Play ping pong
 - Quote characters from Kaamelott universe (and even more!)
 - Manage features' permission based on Discord roles
-
-# Documentation
-
-## Users
-
-In the configuration, the prefix to call the bot can be changed. The default value being "kadok".
-
-## Developers
-
-For the developers documentation, please check: https://godoc.org/github.com/Terag/kadok
-
-Or run godoc locally to generate the documentation.
 
 # Installation
 
@@ -191,6 +178,7 @@ Available options:
 ### Using Docker
 
 > Soon to come !
+
 
 # Information
 

--- a/docs/usages.md
+++ b/docs/usages.md
@@ -1,0 +1,30 @@
+# Features
+
+# General
+
+### Help
+
+```
+kadok help
+```
+
+**Permission:** GetHelp
+
+Returns available actions from the bot.
+
+### Aqui
+
+```
+kadok aqui
+```
+
+**Permission:** GetCharacterList
+
+Returns available characters for quotes.
+
+### Quoting
+
+**Permission:** CallCharacter
+
+Quotes a character if found in one of your messages.
+Use `kadok aqui` to get the list of available characters in your guild.


### PR DESCRIPTION
This pull request:

 - closes #6 :
   - Documenting the code for use of godoc by the developers
   - Creating docs folder for md linked to github page documenting the project. This documentation addresses: users, developers and future contributors. (The github page is automatically generated from md files in the docs folder. Will be visible on https://terag.github.io/kadok/ and http://kadok.pedestres.fr/ when the master is updated)
   - Add the credit and contributors information