### PR TITLE
Correct error in permissions and prefix check

### DIFF
--- a/kadok.go
+++ b/kadok.go
@@ -115,6 +115,19 @@ func main() {
 // message is created on any channel that the autenticated bot has access to.
 func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
+	// Prevent the bot from crashing in the event of the goroutine panicking
+	// It also returns an "Oups problème !" to inform the user that an error happend
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Kadok paaaaaanic !")
+			fmt.Println(r)
+			_, err := s.ChannelMessageSend(m.ChannelID, "Oups problème !")
+			if err != nil {
+				fmt.Println(err)
+			}
+		}
+	}()
+
 	// Ignore all messages created by the bot itself
 	if m.Author.ID == s.State.User.ID {
 		return

--- a/kadok.go
+++ b/kadok.go
@@ -115,6 +115,11 @@ func main() {
 // message is created on any channel that the autenticated bot has access to.
 func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
+	// Ignore all messages created by the bot itself
+	if m.Author.ID == s.State.User.ID {
+		return
+	}
+
 	// Prevent the bot from crashing in the event of the goroutine panicking
 	// It also returns an "Oups problème !" to inform the user that an error happend
 	defer func() {
@@ -128,11 +133,6 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 		}
 	}()
 
-	// Ignore all messages created by the bot itself
-	if m.Author.ID == s.State.User.ID {
-		return
-	}
-
 	roles, err := GetUserRoles(s, m)
 	if err != nil {
 		fmt.Println("Error retrieving user roles")
@@ -140,7 +140,8 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 	isGranted := security.MakeIsGranted(Configuration.Security.RolesHierarchy, roles)
 
-	if strings.ToUpper(m.Content[:len(Configuration.Prefix)]) == strings.ToUpper(Configuration.Prefix) {
+	// Check if the first letters of the message match with the bot command prefix
+	if len(m.Content) >= len(Configuration.Prefix) && strings.ToUpper(m.Content[:len(Configuration.Prefix)]) == strings.ToUpper(Configuration.Prefix) {
 		call := strings.Fields(m.Content)
 		action, executeAction := ResolveAction(&RootAction, call[1:])
 

--- a/security/security.go
+++ b/security/security.go
@@ -128,8 +128,10 @@ func MakeIsGranted(rolesTree RolesTree, playerDiscordRoles []string) func(permis
 		}
 		// Check that the permission is granted
 		for _, role := range playerDiscordRoles {
-			if rolesTree.Roles[role].IsGranted(entity.GetPermission()) {
-				return true
+			if treeRole, ok := rolesTree.Roles[role]; ok {
+				if treeRole.IsGranted(entity.GetPermission()) {
+					return true
+				}
 			}
 		}
 		return false


### PR DESCRIPTION
Close #29 

This PR is mainly about fixing issues that can possibly make the bot to crash or miss behave:

- Correct an error that can make the bot to panic if the permission hierarchy does not define all the roles as the Discord guild.
- Correct an error on prefix check that makes the bot to crash when the message is too short `message.length < prefix.length`
- Add a fallback to prevent panic state from making the bot to crash.