### PR TITLE
Correct error on HTTPS in documentation

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,6 +4,9 @@ description: "Where's Kadoc? Is he well hidden?"
 footer_content: "Kadok is maintained by the team of \"Les Petits Pédestres\" under the <a href=\"https://github.com/Terag/kadok/blob/master/LICENSE\">GNU GENERAL PUBLIC LICENSE Version 3.</a>"
 color_scheme: nil
 search_enabled: false
+heading_anchors: true
+baseurl: ""
+url: "https://kadok.pedestres.fr"
 aux_links:
   "Kadok on GitHub":
     - "//github.com/Terag/kadok"


### PR DESCRIPTION
Close #31 

Add parameters to github page configuration to make sure that the base url for resources is https:
```yaml
baseurl: ""
url: "https://kadok.pedestres.fr"
```