### PR TITLE
Add Procfile for Heroku deployments

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: bin/kadok -t $API_TOKEN


### PR DESCRIPTION
Close #18 by adding a `Procfile` to allow simple deployment on Heroku.

In the Heroku application settings, the var `API_TOKEN` has to be set with the token given by discord to allow the bot to connect to discord's API. You can also set Heroku to wait for the CI validation before to deploy.

Simple deployment to Heroku is enough for now, it may change if Kadok evolves in a more complex way.